### PR TITLE
Add option to serve directory under /static/

### DIFF
--- a/maputnik.go
+++ b/maputnik.go
@@ -27,6 +27,10 @@ func main() {
 			Name:  "watch",
 			Usage: "Notify web client about JSON style file changes",
 		},
+		cli.StringFlag{
+			Name:  "static",
+			Usage: "Serve directory under /static/",
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -50,6 +54,11 @@ func main() {
 					filewatch.ServeWebsocketFileWatcher(filename, w, r)
 				})
 			}
+		}
+		staticDir := c.String("static")
+		if staticDir != "" {
+			h := http.StripPrefix("/static/", http.FileServer(http.Dir(staticDir)))
+			router.PathPrefix("/static/").Handler(h)
 		}
 
 		router.PathPrefix("/").Handler(http.StripPrefix("/", gui))


### PR DESCRIPTION
Closes https://github.com/maputnik/editor/issues/183

This adds the CLI parameter `--static <value>` which interprets value as a directory that, if it exists, will be served under http://localhost:8000/static/ . As written in https://github.com/maputnik/editor/issues/183 I am using this to server sprites and glyphs which I  modify locally at the same time while editing a GL style in Maputnik. 