### PR TITLE
Fixed the error `cannot use cli.StringFlag literal ...`

### DIFF
--- a/maputnik.go
+++ b/maputnik.go
@@ -19,15 +19,15 @@ func main() {
 	app.Version = "Editor: 1.6.1; Desktop: 1.0.4"
 
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "file, f",
 			Usage: "Allow access to JSON style from web client",
 		},
-		cli.BoolFlag{
+		&cli.BoolFlag{
 			Name:  "watch",
 			Usage: "Notify web client about JSON style file changes",
 		},
-		cli.IntFlag{
+		&cli.IntFlag{
 			Name: "port",
 			Value: 8000,
 			Usage: "TCP port to listen on",


### PR DESCRIPTION
This PR fixes the following error.
I am not 100% sure, but it works for me. :)

```
gox -osarch "windows/amd64 linux/amd64 darwin/amd64" -output "bin/{{.OS}}/maputnik"
Number of parallel builds: 3

-->   windows/amd64: github.com/maputnik/desktop
-->     linux/amd64: github.com/maputnik/desktop
-->    darwin/amd64: github.com/maputnik/desktop

3 errors occurred:
--> windows/amd64 error: exit status 2
Stderr: # github.com/maputnik/desktop
./maputnik.go:22:17: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
	cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)
./maputnik.go:26:15: cannot use cli.BoolFlag literal (type cli.BoolFlag) as type cli.Flag in array or slice literal:
	cli.BoolFlag does not implement cli.Flag (Apply method has pointer receiver)
./maputnik.go:30:14: cannot use cli.IntFlag literal (type cli.IntFlag) as type cli.Flag in array or slice literal:
	cli.IntFlag does not implement cli.Flag (Apply method has pointer receiver)

--> linux/amd64 error: exit status 2
Stderr: # github.com/maputnik/desktop
./maputnik.go:22:17: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
	cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)
./maputnik.go:26:15: cannot use cli.BoolFlag literal (type cli.BoolFlag) as type cli.Flag in array or slice literal:
	cli.BoolFlag does not implement cli.Flag (Apply method has pointer receiver)
./maputnik.go:30:14: cannot use cli.IntFlag literal (type cli.IntFlag) as type cli.Flag in array or slice literal:
	cli.IntFlag does not implement cli.Flag (Apply method has pointer receiver)

--> darwin/amd64 error: exit status 2
Stderr: # github.com/maputnik/desktop
./maputnik.go:22:17: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
	cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)
./maputnik.go:26:15: cannot use cli.BoolFlag literal (type cli.BoolFlag) as type cli.Flag in array or slice literal:
	cli.BoolFlag does not implement cli.Flag (Apply method has pointer receiver)
./maputnik.go:30:14: cannot use cli.IntFlag literal (type cli.IntFlag) as type cli.Flag in array or slice literal:
	cli.IntFlag does not implement cli.Flag (Apply method has pointer receiver)

make: *** [maputnik] Error 1
```

Related: https://github.com/urfave/cli/issues/459